### PR TITLE
Support .NET 4.5+

### DIFF
--- a/NestIn/source.extension.vsixmanifest
+++ b/NestIn/source.extension.vsixmanifest
@@ -18,7 +18,7 @@
         <Edition>Pro</Edition>
       </VisualStudio>
     </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.5" MaxVersion="4.5" />
+    <SupportedFrameworkRuntimeEdition MinVersion="4.5" />
   </Identifier>
   <References>
         <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">


### PR DESCRIPTION
After installing the VS CTP, which includes the .NET 4.6 CTP, I was unable to install the plugin in my previous Visual Studio. (Despite the code working just fine)

Removing the Max .NET version shouldn't be harmful and resolves the issue
